### PR TITLE
Fix filename encoding error

### DIFF
--- a/snake/routes/download.py
+++ b/snake/routes/download.py
@@ -7,6 +7,7 @@ Attributes:
 from snake.core import snake_handler
 from snake.db import async_file_collection
 from snake.utils import file_storage as fs
+from urllib.parse import quote
 
 
 # pylint: disable=abstract-method
@@ -25,7 +26,7 @@ class DownloadHandler(snake_handler.SnakeHandler):
         file_storage = fs.FileStorage(sha256_digest)
         buf_size = 4096
         self.set_header('Content-Type', 'application/octet-stream')
-        self.set_header('Content-Disposition', 'attachment; filename="' + document['name'] + '.inactive"')
+        self.set_header('Content-Disposition', 'attachment; filename="' + quote(document['name']) + '.inactive"')
         with open(file_storage.file_path, 'rb') as f:
             while True:
                 data = f.read(buf_size)


### PR DESCRIPTION
Hello developers,

This PR fix the error when downloading the file with non-ascii characters in the filename (for example: `測試.txt`) from web interface.

Here is the error message:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/tornado-5.0.1-py3.7-linux-x86_64.egg/tornado/web.py", line 1543, in _execute
  result = yield result
  File "/usr/local/lib/python3.7/dist-packages/tornado-5.0.1-py3.7-linux-x86_64.egg/tornado/gen.py", line 1099, in run
  value = future.result()
  File "/usr/local/lib/python3.7/dist-packages/snake-1.0.2-py3.7.egg/snake/routes/download.py", line 35, in get
  self.finish()
  File "/usr/local/lib/python3.7/dist-packages/tornado-5.0.1-py3.7-linux-x86_64.egg/tornado/web.py", line 1018, in finish
  self.flush(include_footers=True)
  File "/usr/local/lib/python3.7/dist-packages/tornado-5.0.1-py3.7-linux-x86_64.egg/tornado/web.py", line 973, in flush
  start_line, self._headers, chunk, callback=callback)
  File "/usr/local/lib/python3.7/dist-packages/tornado-5.0.1-py3.7-linux-x86_64.egg/tornado/http1connection.py", line 385, in write_headers
  lines.extend(l.encode('latin1') for l in header_lines)
  File "/usr/local/lib/python3.7/dist-packages/tornado-5.0.1-py3.7-linux-x86_64.egg/tornado/http1connection.py", line 385, in <genexpr>
  lines.extend(l.encode('latin1') for l in header_lines)
UnicodeEncodeError: 'latin-1' codec can't encode characters in position 43-44: ordinal not in range(256)
```
