### PR TITLE
Pinning module mccabe to verion 0.6.1 for flake8 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
     zip_safe=False,
 
     setup_requires=[
+        'mccabe==0.6.1',
         'flake8',
         'pylint',
         'pytest-runner',


### PR DESCRIPTION
When building the snake docker-compose containers, the latest version of mccabe was being used (0.7.0) which conflicts with flake8.

This commit pins mccabe to 0.6.1 which is compatible and the docker build process works as expected.